### PR TITLE
Changed graph plotting functions to input the output of processDocument

### DIFF
--- a/R/ExtractFeatures.R
+++ b/R/ExtractFeatures.R
@@ -52,17 +52,15 @@ char_to_feature = function(character, dims, uniqueid){
 #'
 #' Internal function for drawing a line from two given nodes.
 #'  
-#' @param img full image matrix; used to call plotImageThinned()
-#' @param thinned thinned image matrix; used to call plotImageThinned()
-#' @param nodeList list of nodes
+#' @param doc A document processed with [handwriter::processHandwriter()]
 #' @param nodeSize size of node; default set to 3
 #' @param nodeColor color of node; default set to red
 #' @return a line in between the two nodes
-plotNodesLine = function(img, thinned, nodeList, nodeSize = 3, nodeColor = "red")
+plotNodesLine = function(doc, nodeSize = 3, nodeColor = "red")
 {
   X <- Y <- NULL
-  p = plotImageThinned(img, thinned)
-  pointSet = data.frame(X = ((nodeList - 1) %/% dim(img)[1]) + 1, Y = dim(img)[1] - ((nodeList - 1) %% dim(img)[1]))
+  p = plotImageThinned(doc)
+  pointSet = data.frame(X = ((doc$process$nodes - 1) %/% dim(doc$image)[1]) + 1, Y = dim(doc$image)[1] - ((doc$process$nodes - 1) %% dim(doc$image)[1]))
   sx = pointSet[[1]][[1]]
   sy = pointSet[[2]][[1]]
   ex = pointSet[[1]][[2]]
@@ -72,11 +70,11 @@ plotNodesLine = function(img, thinned, nodeList, nodeSize = 3, nodeColor = "red"
   return(p)
 }
 
-plotNodesLine1 = function(img, thinned, nodeList, nodeSize = 3, nodeColor = "red")
+plotNodesLine1 = function(doc, nodeSize = 3, nodeColor = "red")
 {
   X <- Y <- NULL
-  p = plotImageThinned(img, thinned)
-  pointSet = data.frame(X = ((nodeList - 1) %/% dim(img)[1]) + 1, Y = dim(img)[1] - ((nodeList - 1) %% dim(img)[1]))
+  p = plotImageThinned(doc)
+  pointSet = data.frame(X = ((doc$process$nodes - 1) %/% dim(doc$image)[1]) + 1, Y = dim(doc$image)[1] - ((doc$process$nodes - 1) %% dim(doc$image)[1]))
   sx = pointSet[[1]][[1]]
   sy = pointSet[[2]][[1]]
   ex = pointSet[[1]][[2]]

--- a/R/data.R
+++ b/R/data.R
@@ -6,9 +6,9 @@
 #' @examples
 #' csafe_document <- list()
 #' csafe_document$image <- csafe
-#' plotImage(csafe_document$image)
+#' plotImage(csafe_document)
 #' csafe_document$thin <- thinImage(csafe_document$image)
-#' plotImageThinned(csafe_document$image, csafe_document$thin)
+#' plotImageThinned(csafe_document)
 #' csafe_processList <- processHandwriting(csafe_document$thin, dim(csafe_document$image))
 "csafe"
 
@@ -18,9 +18,9 @@
 #' @examples
 #' london_document <- list()
 #' london_document$image <- london
-#' plotImage(london_document$image)
+#' plotImage(london_document)
 #' london_document$thin <- thinImage(london_document$image)
-#' plotImageThinned(london_document$image, london_document$thin)
+#' plotImageThinned(london_document)
 #' london_processList <- processHandwriting(london_document$thin, dim(london_document$image))
 "london"
 
@@ -31,9 +31,9 @@
 #' \dontrun{
 #' message_document <- list()
 #' message_document$image <- message
-#' plotImage(message_document$image)
+#' plotImage(message_document)
 #' message_document$thin <- thinImage(message_document$image)
-#' plotImageThinned(message_document$image, message_document$thin)
+#' plotImageThinned(message_document)
 #' message_processList <- processHandwriting(message_document$thin, dim(message_document$image))
 #' }
 "message"
@@ -45,9 +45,9 @@
 #' \dontrun{
 #' nature1_document <- list()
 #' nature1_document$image <- nature1
-#' plotImage(nature1_document$image)
+#' plotImage(nature1_document)
 #' nature1_document$thin <- thinImage(nature1_document$image)
-#' plotImageThinned(nature1_document$image, nature1_document$thin)
+#' plotImageThinned(nature1_document)
 #' nature1_processList <- processHandwriting(nature1_document$thin, dim(nature1_document$image))
 #' }
 "nature1"
@@ -59,9 +59,9 @@
 #' \dontrun{
 #' twoSent_document <- list()
 #' twoSent_document$image <- twoSent
-#' plotImage(twoSent_document$image)
+#' plotImage(twoSent_document)
 #' twoSent_document$thin <- thinImage(twoSent_document$image)
-#' plotImageThinned(twoSent_document$image, twoSent_document$thin)
+#' plotImageThinned(twoSent_document)
 #' twoSent_processList <- processHandwriting(twoSent_document$thin, dim(twoSent_document$image))
 #' }
 "twoSent"

--- a/man/csafe.Rd
+++ b/man/csafe.Rd
@@ -16,9 +16,9 @@ Cursive written word: csafe
 \examples{
 csafe_document <- list()
 csafe_document$image <- csafe
-plotImage(csafe_document$image)
+plotImage(csafe_document)
 csafe_document$thin <- thinImage(csafe_document$image)
-plotImageThinned(csafe_document$image, csafe_document$thin)
+plotImageThinned(csafe_document)
 csafe_processList <- processHandwriting(csafe_document$thin, dim(csafe_document$image))
 }
 \keyword{datasets}

--- a/man/london.Rd
+++ b/man/london.Rd
@@ -16,9 +16,9 @@ Cursive written word: London
 \examples{
 london_document <- list()
 london_document$image <- london
-plotImage(london_document$image)
+plotImage(london_document)
 london_document$thin <- thinImage(london_document$image)
-plotImageThinned(london_document$image, london_document$thin)
+plotImageThinned(london_document)
 london_processList <- processHandwriting(london_document$thin, dim(london_document$image))
 }
 \keyword{datasets}

--- a/man/message.Rd
+++ b/man/message.Rd
@@ -17,9 +17,9 @@ Full page image of the handwritten London letter.
 \dontrun{
 message_document <- list()
 message_document$image <- message
-plotImage(message_document$image)
+plotImage(message_document)
 message_document$thin <- thinImage(message_document$image)
-plotImageThinned(message_document$image, message_document$thin)
+plotImageThinned(message_document)
 message_processList <- processHandwriting(message_document$thin, dim(message_document$image))
 }
 }

--- a/man/nature1.Rd
+++ b/man/nature1.Rd
@@ -17,9 +17,9 @@ Full page image of the 4th sample (nature) of handwriting from the first writer.
 \dontrun{
 nature1_document <- list()
 nature1_document$image <- nature1
-plotImage(nature1_document$image)
+plotImage(nature1_document)
 nature1_document$thin <- thinImage(nature1_document$image)
-plotImageThinned(nature1_document$image, nature1_document$thin)
+plotImageThinned(nature1_document)
 nature1_processList <- processHandwriting(nature1_document$thin, dim(nature1_document$image))
 }
 }

--- a/man/plotImage.Rd
+++ b/man/plotImage.Rd
@@ -4,21 +4,26 @@
 \alias{plotImage}
 \title{plotImage}
 \usage{
-plotImage(x)
+plotImage(doc)
 }
 \arguments{
-\item{x}{Binary matrix, usually from readPNGBinary}
+\item{doc}{A document processed with [handwriter::processDocument()] or a binary matrix (all entries are 0 or 1)}
 }
 \value{
-Returns plot of x.
+Returns plot of doc$image.
 }
 \description{
-This function plots a basic binary image.
+This function plots a basic black and white image.
 }
 \examples{
-csafe_document = list()
-csafe_document$image = csafe
-plotImage(csafe_document$image)
+csafe_document <- list()
+csafe_document$image <- csafe
+plotImage(csafe_document)
+
+\dontrun{
+document = processDocument('path/to/image.png')
+plotImage(document)
+}
 
 }
 \keyword{plot}

--- a/man/plotImageThinned.Rd
+++ b/man/plotImageThinned.Rd
@@ -4,24 +4,20 @@
 \alias{plotImageThinned}
 \title{plotImageThinned}
 \usage{
-plotImageThinned(img, thinned)
+plotImageThinned(doc)
 }
 \arguments{
-\item{img}{Full image matrix}
-
-\item{thinned}{Thinned image matrix}
+\item{doc}{A document processed with [handwriter::processHandwriting()]}
 }
 \value{
-Plot of full and thinned image.
+Plot of thinned image
 }
 \description{
 This function returns a plot with the full image plotted in light gray and the skeleton printed in black on top.
 }
 \examples{
 \dontrun{
-csafe_document = list()
-csafe_document$image = nature1
-csafe_document$thin = thinImage(csafe_document$image)
-plotImageThinned(csafe_document$image, csafe_document$thin)
+document = processHandwriting('path/to/image.png')
+plotImageThinned(document)
 }
 }

--- a/man/plotLetter.Rd
+++ b/man/plotLetter.Rd
@@ -5,9 +5,8 @@
 \title{plotLetter}
 \usage{
 plotLetter(
-  letterList,
+  doc,
   whichLetter,
-  dims,
   showPaths = TRUE,
   showCentroid = TRUE,
   showSlope = TRUE,
@@ -15,11 +14,9 @@ plotLetter(
 )
 }
 \arguments{
-\item{letterList}{Letter list from processHandwriting function}
+\item{doc}{A document processed with [handwriter::processDocument()]}
 
 \item{whichLetter}{Single value in 1:length(letterList) denoting which letter to plot.}
-
-\item{dims}{Dimensions of the original document}
 
 \item{showPaths}{Whether the calculated paths on the letter should be shown with numbers.}
 
@@ -41,9 +38,8 @@ Dims requires the dimensions of the entire document, since this isn't contained 
 twoSent_document = list()
 twoSent_document$image = twoSent
 twoSent_document$thin = thinImage(twoSent_document$image)
-twoSent_processList = processHandwriting(twoSent_document$thin, dim(twoSent_document$image))
+twoSent_document$process = processHandwriting(twoSent_document$thin, dim(twoSent_document$image))
+plotLetter(twoSent_document, 1)
+plotLetter(twoSent_document, 4, showPaths = FALSE)
 
-dims = dim(twoSent_document$image)
-plotLetter(twoSent_processList$letterList, 1, dims)
-plotLetter(twoSent_processList$letterList, 4, dims)
 }

--- a/man/plotNodes.Rd
+++ b/man/plotNodes.Rd
@@ -4,14 +4,12 @@
 \alias{plotNodes}
 \title{plotNodes}
 \usage{
-plotNodes(img, thinned, nodeList, nodeSize = 3, nodeColor = "red")
+plotNodes(doc, plot_break_pts = FALSE, nodeSize = 3, nodeColor = "red")
 }
 \arguments{
-\item{img}{Full image matrix, unthinned.}
+\item{doc}{A document processed with [handwriter::processHandwriting()]}
 
-\item{thinned}{Thinned image matrix}
-
-\item{nodeList}{Nodelist returned from getNodes.}
+\item{plot_break_pts}{Logical value as to whether to plot nodes or break points. plot_break_pts=FALSE plots nodes and plot_break_pts=TRUE plots break point.}
 
 \item{nodeSize}{Size of triangles printed. 3 by default. Move down to 2 or 1 for small text images.}
 
@@ -26,14 +24,10 @@ Also called from plotPath, which is a more useful function, in general.
 }
 \examples{
 \dontrun{
-twoSent_document = list()
-twoSent_document$image = twoSent
-twoSent_document$thin = thinImage(twoSent_document$image)
-twoSent_processList = processHandwriting(twoSent_document$thin, dim(twoSent_document$image))
-
-twoSent_document$nodes = twoSent_processList$nodes
-twoSent_document$breaks = twoSent_processList$breakPoints
-plotNodes(twoSent_document$image, twoSent_document$thin, twoSent_document$nodes)
-plotNodes(twoSent_document$image, twoSent_document$thin, twoSent_document$breaks)
+twoSent_doc = list()
+twoSent_doc$image = twoSent
+twoSent_doc$thin = thinImage(twoSent_doc$image)
+twoSent_doc$process = processHandwriting(twoSent_doc$thin, dim(twoSent_doc$image))
+plotNodes(twoSent_doc)
 }
 }

--- a/man/plotNodesLine.Rd
+++ b/man/plotNodesLine.Rd
@@ -4,14 +4,10 @@
 \alias{plotNodesLine}
 \title{plotNodesLine}
 \usage{
-plotNodesLine(img, thinned, nodeList, nodeSize = 3, nodeColor = "red")
+plotNodesLine(doc, nodeSize = 3, nodeColor = "red")
 }
 \arguments{
-\item{img}{full image matrix; used to call plotImageThinned()}
-
-\item{thinned}{thinned image matrix; used to call plotImageThinned()}
-
-\item{nodeList}{list of nodes}
+\item{doc}{A document processed with [handwriter::processHandwriter()]}
 
 \item{nodeSize}{size of node; default set to 3}
 

--- a/man/twoSent.Rd
+++ b/man/twoSent.Rd
@@ -17,9 +17,9 @@ Two sentence printed example handwriting
 \dontrun{
 twoSent_document <- list()
 twoSent_document$image <- twoSent
-plotImage(twoSent_document$image)
+plotImage(twoSent_document)
 twoSent_document$thin <- thinImage(twoSent_document$image)
-plotImageThinned(twoSent_document$image, twoSent_document$thin)
+plotImageThinned(twoSent_document)
 twoSent_processList <- processHandwriting(twoSent_document$thin, dim(twoSent_document$image))
 }
 }

--- a/src/ThinImageCpp.cpp
+++ b/src/ThinImageCpp.cpp
@@ -307,7 +307,7 @@ void countWBTransitions(const arma::mat &img, uvec checkList, vec &toWhite)
 #message = list()
 #message$image = crop(img)
 #message$thin = thinImage(message$image)
-#plotImageThinned(message$image, message$thin)
+#plotImageThinned(message)
 
 #test = png::readPNG("/Users/Nick/Documents/Projects/CSAFE/Handwriting/data/Writing_csafe_all.png")
 #dim(test)


### PR DESCRIPTION
Reasons for the change

1. Previously, if doc <- processDocument() then users would need to remember to call plotImage(doc$image) or plotNodes(doc$image, doc$thin, doc$process$nodes) etc.  Now they can simply call plotImage(doc) or plotNodes(doc) etc.
2. Initially, I was only going to allow plotImage() to work on the output of processDocument() but plotLine calls plotImage() on a binary matrix. There might be other times that users want to plot binary matrices as well, so plotImage() can accept a binary matrix or the output of processDocument()
3. To fix a bug in plotImageThinned() where it doesn't throw and error even if it isn't called with enough arguments.

Updated functions:

1. plotNodesLine (internal)
2. plotNodesLine1 (internal)
3. plotImage
4. plotImageThinned
5. plotLetter
6. plotNodes
7. plotNodesLine

Updated examples accordingly.

devtools::check() runs with 1 warning and 3 notes.