### PR TITLE
fix initializer warning with arma::vec

### DIFF
--- a/src/ThinImageCpp.cpp
+++ b/src/ThinImageCpp.cpp
@@ -203,7 +203,7 @@ void count246(const arma::mat &img, uvec checkList, vec &toWhite)
   for(int i = 0; i < checkList.n_elem; i++)
   {
     cell = checkList[i];
-    neighbors << img[cell - 1] << img[cell + n] << img[cell + 1];
+    neighbors = { img[cell - 1], img[cell + n], img[cell + 1] };
     if(any(neighbors == 1))
       toWhite[i] = 1;
   }


### PR DESCRIPTION
apparently different versions of gcc were raising warnings with the assignment of values in neighbors. The recommended fix was to use an initializer list, which is explained in the arma doc below.

https://arma.sourceforge.net/docs.html#element_initialisation