### PR TITLE
Fixes in format_questioned_data and get_writer_pis

### DIFF
--- a/R/ClusterModeling_datafunctions.R
+++ b/R/ClusterModeling_datafunctions.R
@@ -218,14 +218,15 @@ format_questioned_data <- function(model, questioned_clusters, writer_indices, d
     full_cluster_fill_counts <- as.data.frame(matrix(0, nrow = nrow(cluster_fill_counts), ncol = ncol(model$cluster_fill_counts)))
     # fill column names
     colnames(full_cluster_fill_counts) <- colnames(model$cluster_fill_counts)
-    # fill writers and docs
+    # fill writers and docs and docnames
     full_cluster_fill_counts$writer <- cluster_fill_counts$writer
     full_cluster_fill_counts$doc <- cluster_fill_counts$doc
+    full_cluster_fill_counts$docname <- cluster_fill_counts$docname
     # add missing columns
     full_cluster_fill_counts <- dplyr::left_join(cluster_fill_counts, full_cluster_fill_counts) %>% 
       dplyr::mutate(dplyr::across(dplyr::where(is.numeric), ~ tidyr::replace_na(.x, 0)))
     # sort columns
-    cols <- c(colnames(full_cluster_fill_counts[, c(1, 2)]), sort(as.numeric(colnames(full_cluster_fill_counts[, -c(1, 2)]))))
+    cols <- c(colnames(full_cluster_fill_counts[, c(1, 2, 3)]), sort(as.numeric(colnames(full_cluster_fill_counts[, -c(1, 2, 3)]))))
     full_cluster_fill_counts <- full_cluster_fill_counts[, cols]
     # rename
     cluster_fill_counts <- full_cluster_fill_counts

--- a/R/ClusterModeling_modelfunctions.R
+++ b/R/ClusterModeling_modelfunctions.R
@@ -398,7 +398,7 @@ get_pi_dataframes <- function(model) {
   # get a data frame of pis for a specific writer
   get_writer_pis <- function(flat_pi, writer){
     # select writer's columns in flat_pi
-    writer_cols <- colnames(flat_pi)[grepl(paste0("pi\\[", writer, ",*"), colnames(flat_pi))]
+    writer_cols <- colnames(flat_pi)[grepl(paste0("pi\\[", writer, ","), colnames(flat_pi))]
     writer_pis <- flat_pi[,c("iters", "writer", writer_cols)]
     # add writer to data frame
     writer_pis$writer <- writer


### PR DESCRIPTION
In function format_questioned_data only the doc as well as writer columns were filled in case the questioned document cluster count had fewer clusters than the model number of clusters.

The routine did a left join but the docname was not filled and hence the function was erroring out.
Furthermore, in the output it wasn't including the docname as well.

After the changes I propose I was able to avoid the error and get the end analysis result.

In function get_writer_pis the current regex was matching `pi[10,4]` even if the writer is 1, So fixed it so it only matches to the first value to be 1 when writer is 1. It fixed the plot_credible_intervals function at the end `numbers of columns of arguments do not match`