### PR TITLE
120 skip to next

### DIFF
--- a/R/ClusterMakeTemplates.R
+++ b/R/ClusterMakeTemplates.R
@@ -93,8 +93,7 @@ make_clustering_templates <- function(template_dir,
   message("Processing template training documents...")
   process_batch_dir(
     input_dir = template_images_dir,
-    output_dir = file.path(template_dir, "data", "template_graphs"),
-    return_result = FALSE
+    output_dir = file.path(template_dir, "data", "template_graphs")
   )
 
   # Make proclist ----

--- a/R/ClusterModeling_analysisfunctions.R
+++ b/R/ClusterModeling_analysisfunctions.R
@@ -58,7 +58,7 @@ analyze_questioned_documents <- function(template_dir, questioned_images_dir, mo
   
   # process questioned documents
   message("Processing questioned documents...")
-  questioned_proc_list <- process_batch_dir(
+  process_batch_dir(
     input_dir = questioned_images_dir,
     output_dir = file.path(template_dir, "data", "questioned_graphs")
   )

--- a/R/ClusterModeling_modelfunctions.R
+++ b/R/ClusterModeling_modelfunctions.R
@@ -101,8 +101,7 @@ fit_model <- function(template_dir,
   message("Processing model documents...")
   process_batch_dir(
     input_dir = model_images_dir,
-    output_dir = file.path(template_dir, "data", "model_graphs"),
-    return_result = FALSE
+    output_dir = file.path(template_dir, "data", "model_graphs")
   )
 
   # get cluster assignments

--- a/R/JunctionDetection.R
+++ b/R/JunctionDetection.R
@@ -1097,7 +1097,7 @@ letterPaths <- function(allPaths, nodeGraph0, breakPoints) {
     expr = {
       dists <- distances(nodeGraph0, v = names(V(nodeGraph0)), to = names(V(nodeGraph0)), weights = E(nodeGraph0)$nodeOnlyDist)
     }, error = function(e) {
-      message("Unusual amounts of interconnected paths being detected. Do you have crossed out writing in your document?")
+      message(paste(e, "Do you have crossed out writing in your document?"))
     }
   )
 

--- a/R/JunctionDetection.R
+++ b/R/JunctionDetection.R
@@ -337,7 +337,7 @@ processHandwriting <- function(img, dims) {
   letters <- letterList[[1]][unlist(lapply(letterList[[1]], length)) > 5]
 
   V(skel_graph0)$letterID <- letterList[[2]]
-  skel_graph0 <- delete.vertices(skel_graph0, V(skel_graph0)[which(V(skel_graph0)$letterID %in% which(unlist(lapply(letterList[[1]], length)) <= 5))])
+  skel_graph0 <- igraph::delete_vertices(skel_graph0, V(skel_graph0)[which(V(skel_graph0)$letterID %in% which(unlist(lapply(letterList[[1]], length)) <= 5))])
   V(skel_graph0)$letterID[!is.na(V(skel_graph0)$letterID)] <- as.numeric(as.factor(na.omit(V(skel_graph0)$letterID)))
 
   # Remove breakpoints that shouldn't have broken.
@@ -446,15 +446,15 @@ AllUniquePaths <- function(adj, graph, graph0) {
     fromNode <- as.character(format(adj[i, 1], scientific = FALSE, trim = TRUE))
     toNode <- as.character(format(adj[i, 2], scientific = FALSE, trim = TRUE))
 
-    while (shortest.paths(graph0, v = fromNode, to = toNode, weights = E(graph0)$nodeOnlyDist) < 3 & shortest.paths(graph0, v = fromNode, to = toNode, weights = E(graph0)$nodeOnlyDist) >= 1) {
+    while (igraph::distances(graph0, v = fromNode, to = toNode, weights = E(graph0)$nodeOnlyDist) < 3 & distances(graph0, v = fromNode, to = toNode, weights = E(graph0)$nodeOnlyDist) >= 1) {
       shortest <- shortest_paths(graph0, from = fromNode, to = toNode, weights = E(graph0)$nodeOnlyDist)
       len <- length(unlist(shortest[[1]]))
       paths <- c(paths, list(as.numeric(names(shortest$vpath[[1]]))))
       if (len > 2) {
-        graph <- delete.edges(graph, paste0(names(shortest$vpath[[1]])[len %/% 2], "|", names(shortest$vpath[[1]])[len %/% 2 + 1]))
-        graph0 <- delete.edges(graph0, paste0(names(shortest$vpath[[1]])[len %/% 2], "|", names(shortest$vpath[[1]])[len %/% 2 + 1]))
+        graph <- igraph::delete_edges(graph, paste0(names(shortest$vpath[[1]])[len %/% 2], "|", names(shortest$vpath[[1]])[len %/% 2 + 1]))
+        graph0 <- igraph::delete_edges(graph0, paste0(names(shortest$vpath[[1]])[len %/% 2], "|", names(shortest$vpath[[1]])[len %/% 2 + 1]))
       } else if (len == 2) {
-        graph0 <- delete.edges(graph0, paste0(names(shortest$vpath[[1]])[1], "|", names(shortest$vpath[[1]])[2]))
+        graph0 <- igraph::delete_edges(graph0, paste0(names(shortest$vpath[[1]])[1], "|", names(shortest$vpath[[1]])[2]))
       } else {
         stop("There must be some mistake. Single node should have nodeOnlyDist path length of 0.")
       }
@@ -484,7 +484,7 @@ checkBreakPoints <- function(candidateNodes, allPaths, nodeGraph, terminalNodes,
   {
     tempPath <- format(allPaths[[i]], scientific = FALSE, trim = TRUE)
     nodeChecks <- which(candidateNodes %in% tempPath)
-    tempNodeGraph <- delete.edges(nodeGraph, paste0(tempPath[1], "|", tempPath[length(tempPath)]))
+    tempNodeGraph <- igraph::delete_edges(nodeGraph, paste0(tempPath[1], "|", tempPath[length(tempPath)]))
 
     if (distances(tempNodeGraph, v = tempPath[1], to = tempPath[length(tempPath)]) < Inf) {
       # No breaking on multiple paths between nodes.
@@ -841,7 +841,7 @@ getLoops <- function(nodeList, graph, graph0, pathList, dims) {
       if (length(neighbors) > 0) {
         for (i in 1:length(neighbors)) {
           neigh <- as.numeric(names(neighbors[[i]]))
-          graph <- delete.edges(graph, paste0(neigh[1], "|", neigh[2]))
+          graph <- igraph::delete_edges(graph, paste0(neigh[1], "|", neigh[2]))
           if (distances(graph, v = as.character(neigh[1]), to = as.character(neigh[2])) < Inf) {
             newPath <- as.numeric(names(unlist(shortest_paths(graph, from = format(neigh[1], scientific = FALSE), to = format(neigh[2], scientific = FALSE), weights = E(graph)$pen_dist)$vpath)))
             loopList <- append(loopList, list(c(newPath, newPath[1])))
@@ -922,7 +922,7 @@ getLoops <- function(nodeList, graph, graph0, pathList, dims) {
   while (TRUE) {
     if (length(V(remaining0)) > 0) {
       perfectLoop <- names(na.omit(dfs(remaining0, V(remaining0)[1], unreachable = FALSE)$order))
-      remaining0 <- delete.vertices(remaining0, v = perfectLoop)
+      remaining0 <- igraph::delete_vertices(remaining0, v = perfectLoop)
       loopList <- append(loopList, list(as.numeric(c(perfectLoop, perfectLoop[1]))))
     } else {
       break
@@ -1009,7 +1009,7 @@ getNodeGraph <- function(allPaths, nodeList) {
   nodeGraph <- add_vertices(nodeGraph, length(nodeList), name = format(nodeList, scientific = FALSE, trim = TRUE))
   for (i in 1:length(allPaths))
   {
-    nodeGraph <- add.edges(nodeGraph, format(c(allPaths[[i]][1], allPaths[[i]][length(allPaths[[i]])]), scientific = FALSE, trim = TRUE))
+    nodeGraph <- igraph::add_edges(nodeGraph, format(c(allPaths[[i]][1], allPaths[[i]][length(allPaths[[i]])]), scientific = FALSE, trim = TRUE))
   }
   return(nodeGraph)
 }

--- a/man/process_batch_dir.Rd
+++ b/man/process_batch_dir.Rd
@@ -4,12 +4,17 @@
 \alias{process_batch_dir}
 \title{Process Batch Directory}
 \usage{
-process_batch_dir(input_dir, output_dir = ".")
+process_batch_dir(input_dir, output_dir = ".", skip_docs_on_retry = TRUE)
 }
 \arguments{
 \item{input_dir}{Input directory that contains images}
 
 \item{output_dir}{A directory to save the processed images}
+
+\item{skip_docs_on_retry}{Logical whether to skip documents in input_dir that
+caused errors on a previous run. The errors and document names are stored
+in output_dir > problems.txt. If this is the first run,
+\code{process_batch_list} will attempt to process all documents in input_dir.}
 }
 \value{
 A list of processed documents

--- a/man/process_batch_dir.Rd
+++ b/man/process_batch_dir.Rd
@@ -4,17 +4,12 @@
 \alias{process_batch_dir}
 \title{Process Batch Directory}
 \usage{
-process_batch_dir(input_dir, output_dir = ".", return_result = TRUE)
+process_batch_dir(input_dir, output_dir = ".")
 }
 \arguments{
 \item{input_dir}{Input directory that contains images}
 
 \item{output_dir}{A directory to save the processed images}
-
-\item{return_result}{TRUE/FALSE whether to return the result. If TRUE, the
-processed documents with be saved and a list of the processed documents
-will be returned. If FALSE, the processed documents will be saved, but
-nothing will be returned.}
 }
 \value{
 A list of processed documents
@@ -30,8 +25,8 @@ edges. Then combine edges into component shapes called \emph{graphs}.
 }
 \examples{
 \dontrun{
-process_batch_list("path/to/input_dir", "path/to/output_dir", FALSE)
-docs <- process_batch_list("path/to/input_dir", "path/to/output_dir", TRUE)
+process_batch_list("path/to/input_dir", "path/to/output_dir")
+docs <- process_batch_list("path/to/input_dir", "path/to/output_dir")
 }
 
 }

--- a/man/process_batch_list.Rd
+++ b/man/process_batch_list.Rd
@@ -4,17 +4,12 @@
 \alias{process_batch_list}
 \title{Process Batch List}
 \usage{
-process_batch_list(images, output_dir, return_result = TRUE)
+process_batch_list(images, output_dir)
 }
 \arguments{
 \item{images}{A vector of image file paths}
 
 \item{output_dir}{A directory to save the processed images}
-
-\item{return_result}{TRUE/FALSE whether to return the result. If TRUE, the
-processed documents with be saved and a list of the processed documents
-will be returned. If FALSE, the processed documents will be saved, but
-nothing will be returned.}
 }
 \value{
 A list of processed documents

--- a/man/process_batch_list.Rd
+++ b/man/process_batch_list.Rd
@@ -4,24 +4,29 @@
 \alias{process_batch_list}
 \title{Process Batch List}
 \usage{
-process_batch_list(images, output_dir)
+process_batch_list(images, output_dir, skip_docs_on_retry = TRUE)
 }
 \arguments{
 \item{images}{A vector of image file paths}
 
 \item{output_dir}{A directory to save the processed images}
+
+\item{skip_docs_on_retry}{Logical whether to skip documents in the images arguement that
+caused errors on a previous run. The errors and document names are stored
+in output_dir > problems.txt. If this is the first run,
+\code{process_batch_list} will attempt to process all documents in the images arguement.}
 }
 \value{
 A list of processed documents
 }
 \description{
-Process a list of handwriting samples saved as PNG images:
-(1) Load the image and convert it to black and white with \code{\link[=readPNGBinary]{readPNGBinary()}}
-(2) Thin the handwriting to one pixel in width with \code{\link[=thinImage]{thinImage()}}
-(3) Run \code{\link[=processHandwriting]{processHandwriting()}} to split the handwriting into parts called \emph{edges} and place \emph{nodes} at the ends of
-edges. Then combine edges into component shapes called \emph{graphs}.
-(4) Save the processed document in an RDS file.
-(5) Optional. Return a list of the processed documents.
+Process a list of handwriting samples saved as PNG images: (1) Load the image
+and convert it to black and white with \code{\link[=readPNGBinary]{readPNGBinary()}} (2) Thin the
+handwriting to one pixel in width with \code{\link[=thinImage]{thinImage()}} (3) Run
+\code{\link[=processHandwriting]{processHandwriting()}} to split the handwriting into parts called \emph{edges}
+and place \emph{nodes} at the ends of edges. Then combine edges into component
+shapes called \emph{graphs}. (4) Save the processed document in an RDS file. (5)
+Optional. Return a list of the processed documents.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-processBatch.R
+++ b/tests/testthat/test-processBatch.R
@@ -1,0 +1,6 @@
+test_that("Batch processing a directory works", {
+  expect_no_error(process_batch_dir(input_dir = testthat::test_path("fixtures", "processHandwriting", "samples"),
+                                    output_dir = tempdir(),
+                                    skip_docs_on_retry = TRUE))
+  
+})


### PR DESCRIPTION
Changed `process_batch_list()` to skip to the next document if an error occurs.

## Known bug
If a document produces an out of vector memory error, `process_batch_list()` will skip to the next document as expected. However, after the second or third time `process_batch_list()` encounters the out of vector memory error, R crashes. If I restart R and run `process_batch_list()` this time it skips the doc that previously crashed R. It appears that R can only encounter the out of vector memory error 2-3 times before it crashes. gc() does not fix the problem. 

Also, changes on branch 114-processing-error greatly reduce the vector memory required for `process_batch_list()` so I am cautiously optimistic that this bug won't be encountered nearly as often once 114-processing-error is merged into the main branch of handwriter.