### PR TITLE
Fixed bug in `process_batch_list()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,12 +32,13 @@ Imports:
     Rfast,
     rjags,
     stringr,
-    tidyr
+    tidyr,
 Suggests: 
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
-    coda
+    coda,
+    withr
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 URL: https://github.com/CSAFE-ISU/handwriter

--- a/tests/testthat/test-processBatch.R
+++ b/tests/testthat/test-processBatch.R
@@ -4,3 +4,53 @@ test_that("Batch processing a directory works", {
                                     skip_docs_on_retry = TRUE))
   
 })
+
+test_that("Show problem docs gives correct message when log is empty", {
+  withr::with_file("file1", {
+    writeLines("", "file1")
+    show_problem_docs("file1")
+    expect_message(show_problem_docs("file1"), "All documents were successfully processed...")
+  })
+})
+
+test_that("Show problem docs gives correct message when log does not contain the phrase 'error with document'", {
+  withr::with_file("file1", {
+    writeLines("aklsdmfc oaierj mamv oiaerj oiaejrm avmoimrfio w0001.png", "file1")
+    show_problem_docs("file1")
+    expect_message(show_problem_docs("file1"), "All documents were successfully processed...")
+  })
+})
+
+test_that("Show problem docs gives correct message when log contains as single problem document", {
+  # document has .png extension
+  withr::with_file("file1", {
+    writeLines("error with document w0001_s03_pLND_r01.png", "file1")
+    show_problem_docs("file1")
+    expect_message(show_problem_docs("file1"), "The following documents could not be processed: w0001_s03_pLND_r01.png")
+  })
+})  
+
+test_that("Show problem docs gives correct message when problem document has uppercase file extension", {
+  withr::with_file("file1", {
+    writeLines("error with document w0001_s03_pLND_r01.PNG", "file1")
+    show_problem_docs("file1")
+    expect_message(show_problem_docs("file1"), "The following documents could not be processed: w0001_s03_pLND_r01.PNG")
+  })
+}) 
+
+test_that("Show problem docs gives correct message when log contains as multiple problem documents", {
+  # multiple lines, each with a problem doc
+  withr::with_file("file1", {
+    writeLines(c("error with document w0001_s03_pLND_r01.png", "error with document cvl0001.png"), "file1")
+    show_problem_docs("file1")
+    expect_message(show_problem_docs("file1"), "The following documents could not be processed: w0001_s03_pLND_r01.png, cvl0001.png")
+  })
+})
+
+test_that("Show problem docs gives correct message when log contains as multiple problem documents and line without a document", {
+  withr::with_file("file1", {
+    writeLines(c("error with document w0001_s03_pLND_r01.png", "null", "error with document cvl0001.png"), "file1")
+    show_problem_docs("file1")
+    expect_message(show_problem_docs("file1"), "The following documents could not be processed: w0001_s03_pLND_r01.png, cvl0001.png")
+  })
+})


### PR DESCRIPTION
- Fixed bug so that if problems.txt generated by `process_batch_list()` does not contain any problem documents and error won't occur.
- Created internal helper function `show_problem_docs()` to print the message "All documents were successfully processed..." if problems.txt does not contain the phrase "error with document \<doc1\>" and the message "The following documents could not be processed: \<doc1\>, \<doc2\>, \<doc3\>..." if problems.txt contains the phrase "error with document \<doc1\>" one or more times.
- Wrote tests to check that `show_problem_docs()` displays the expected message