### PR TITLE
attempt C++ port of getGraphInfo

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,25 @@ cleanBinaryImage <- function(img) {
     .Call(`_handwriter_cleanBinaryImage`, img)
 }
 
+#' getGraphInfo_cpp
+#'
+#' Gather and format the parameter values need to calculate the distance
+NULL
+
+#'
+#' @param imageList1 A graph
+#' @param imageList2 A graph
+#' @param isProto1 True or false. Is the graph information in prototype format?
+#' @param isProto2 True or false. Is the graph information in prototype format?
+#' @param numPathCuts An integer number of cuts to make when comparing segments
+NULL
+
+#'
+#' @noRd
+getGraphInfo_cpp <- function(imageList1, imageList2, isProto1, isProto2, numPathCuts) {
+    .Call(`_handwriter_getGraphInfo_cpp`, imageList1, imageList2, isProto1, isProto2, numPathCuts)
+}
+
 #' addToFeatures
 #' 
 #' @param FeatureSet The current list of features that have been calculated

--- a/src/ClusterFuncs.cpp
+++ b/src/ClusterFuncs.cpp
@@ -10,17 +10,17 @@ void graphInfo_subpart1(const Rcpp::List &imageList, bool isProto,
                         int &numPaths, int &letterSize) {
     // Find the sum of the lengths of paths in graph 1
     if (!isProto) {
-        auto allPaths = Rcpp::as<const Rcpp::List &>(imageList["allPaths"]);
+        auto allPaths = Rcpp::as<Rcpp::List>(imageList["allPaths"]);
         numPaths = static_cast<int>(allPaths.size());
         // this should be equivalent to length(unlist(x))?
         int sz = allPaths.size();
         for (int i = 0; i < sz; i++) {
-            letterSize += Rcpp::as<const Rcpp::IntegerVector &>(allPaths[i])
+            letterSize += Rcpp::as<Rcpp::IntegerVector>(allPaths[i])
                               .size();  // typecast??
         }
     } else {
         auto pathEnds =
-            Rcpp::as<const Rcpp::IntegerMatrix &>(imageList["pathEnds"]);
+            Rcpp::as<Rcpp::IntegerMatrix>(imageList["pathEnds"]);
         numPaths = static_cast<int>(
             Rcpp::as<Rcpp::Dimension>(pathEnds.attr("dim"))[0]);
         auto lengths = Rcpp::as<arma::Col<int>>(imageList["lengths"]);
@@ -63,10 +63,10 @@ void graphInfo_subpart2(const Rcpp::List &imageList, bool isProto, int numPaths,
     } else {
         auto centroid = Rcpp::as<arma::rowvec>(imageList["centroid"]);
         auto imagedim = Rcpp::as<Rcpp::Dimension>(
-            Rcpp::as<const Rcpp::IntegerMatrix &>(imageList["image"])
+            Rcpp::as<Rcpp::IntegerMatrix>(imageList["image"])
                 .attr("dim"));
         auto pathEndsrc = Rcpp::as<arma::Cube<double>>(imageList["pathEndsrc"]);
-        auto allPaths = Rcpp::as<const Rcpp::List &>(imageList["allPaths"]);
+        auto allPaths = Rcpp::as<Rcpp::List>(imageList["allPaths"]);
         for (int i = 0; i < numPaths; ++i) {
             auto pvec = Rcpp::as<arma::Col<int>>(allPaths[i]);
             int l = pvec.size();

--- a/src/ClusterFuncs.cpp
+++ b/src/ClusterFuncs.cpp
@@ -69,7 +69,7 @@ void graphInfo_subpart2(Rcpp::List imageList, bool isProto, int numPaths,
             auto pvec = Rcpp::as<arma::Col<int>>(allPaths[i]);
             int l = pvec.size();
             len[i] = l;
-            pe.slice(i) = pathEndsrc.slice(i);  // iffy
+            pe.slice(i).fill(pathEndsrc(i));  // iffy
             auto pathRC = arma::conv_to<arma::Mat<double>>::from(pathToRC(pvec, imagedim));
             cent.subcube(0, 0, i, 0, 1, i) =
                 arma::mean(pathRC, 0) - centroid;

--- a/src/ClusterFuncs.cpp
+++ b/src/ClusterFuncs.cpp
@@ -65,13 +65,13 @@ void graphInfo_subpart2(const Rcpp::List &imageList, bool isProto, int numPaths,
         auto imagedim = Rcpp::as<Rcpp::Dimension>(
             Rcpp::as<Rcpp::IntegerMatrix>(imageList["image"])
                 .attr("dim"));
-        auto pathEndsrc = Rcpp::as<arma::Cube<double>>(imageList["pathEndsrc"]);
+        auto pathEndsrc = Rcpp::as<Rcpp::List>(imageList["pathEndsrc"]);
         auto allPaths = Rcpp::as<Rcpp::List>(imageList["allPaths"]);
         for (int i = 0; i < numPaths; ++i) {
             auto pvec = Rcpp::as<arma::Col<int>>(allPaths[i]);
             int l = pvec.size();
             len[i] = l;
-            pe.slice(i).fill(pathEndsrc(i));
+            pe.slice(i) = Rcpp::as<arma::Mat<double>>(pathEndsrc[i]);
             auto pathRC = pathToRC(pvec, imagedim);
             cent.subcube(0, 0, i, 0, 1, i) = arma::mean(pathRC, 0) - centroid;
             // the Rfast::eachrow

--- a/src/ClusterFuncs.cpp
+++ b/src/ClusterFuncs.cpp
@@ -1,0 +1,150 @@
+#include <RcppArmadillo.h>
+
+#include <algorithm>
+// [[Rcpp::depends(RcppArmadillo)]]
+
+void graphInfo_subpart1(Rcpp::List imageList, bool isProto, int &numPaths,
+                        int &letterSize) {
+    auto allPaths = Rcpp::as<Rcpp::List>(imageList["allPaths"]);
+    auto pathEnds = Rcpp::as<Rcpp::IntegerMatrix>(imageList["pathEnds"]);
+    numPaths = std::max<int>(
+        allPaths.size(), Rcpp::as<Rcpp::Dimension>(pathEnds.attr("dim"))[0]);
+    // Find the sum of the lengths of paths in graph 1
+    if (!isProto) {
+        // this should be equivalent to length(unlist(x))?
+        auto tmp = Rcpp::as<Rcpp::List>(imageList["allPaths"]);
+        int sz = tmp.size();
+        for (int i = 0; i < sz; i++) {
+            letterSize +=
+                Rcpp::as<Rcpp::IntegerVector>(tmp[i]).size();  // typecast??
+        }
+    } else {
+        auto lengths = Rcpp::as<arma::Col<int>>(imageList["lengths"]);
+        letterSize = arma::sum(lengths);
+    }
+}
+
+arma::Mat<int> pathToRC(arma::Col<int> &pvec, Rcpp::Dimension dims) {
+    arma::Mat<int> res(pvec.size(), 2);
+    int d0 = static_cast<int>(dims[0]);
+    res.col(0) = pvec - 1;
+    res.col(1) = pvec - 1;
+    for (int i = 0; i < pvec.size(); ++i) {
+        res.at(i, 0) = 1 + (res.at(i, 0) / d0);
+        res.at(i, 1) = d0 - (res.at(i, 1) % d0);
+    }
+    return res;
+}
+
+void graphInfo_subpart2(Rcpp::List imageList, bool isProto, int numPaths,
+                        int numPathCuts, int pathCheckNum,
+                        arma::Cube<double> &pq, arma::Cube<double> &pe,
+                        arma::Cube<double> &cent, arma::Col<int> &len) {
+    if (isProto) {
+        auto lengths = Rcpp::as<arma::Col<int>>(imageList["lengths"]);
+        auto pathEnds = Rcpp::as<arma::Mat<double>>(imageList["pathEnds"]);
+        auto pathQuarters =
+            Rcpp::as<arma::Mat<double>>(imageList["pathQuarters"]);
+        auto pathCenter = Rcpp::as<arma::Mat<double>>(imageList["pathCenter"]);
+        // numPaths <= pathCheckNum, so we can
+        // skip the bounds check inside the loop
+        // and just have numPaths outside
+        for (int i = 0; i < numPaths; ++i) {
+            len[i] = lengths[i];
+            pe.slice(i) = arma::reshape(pathEnds.row(i), 2, 2).t();
+            cent.subcube(0, 0, i, 0, 1, i) = pathCenter.row(i);
+            pq.slice(i) =
+                arma::reshape(pathQuarters.submat(i, 0, i, 2 * numPathCuts - 3),
+                              2 * numPathCuts - 2, 2)
+                    .t();
+        }
+    } else {
+        auto centroid = Rcpp::as<arma::rowvec>(imageList["centroid"]);
+        auto imagedim = Rcpp::as<Rcpp::Dimension>(
+            Rcpp::as<Rcpp::IntegerMatrix>(imageList["image"]).attr("dim"));
+        auto pathEndsrc = Rcpp::as<Rcpp::List>(imageList["pathEndsrc"]);
+        auto allPaths = Rcpp::as<Rcpp::List>(imageList["allPaths"]);
+        for (int i = 0; i < numPaths; ++i) {
+            // is allPaths[i] an IntegerVector?
+            auto pvec = Rcpp::as<arma::Col<int>>(allPaths[i]);
+            int l = pvec.size();
+            len[i] = l;
+            pe.slice(i) = Rcpp::as<arma::Mat<double>>(pathEndsrc[i]);
+            auto pathRC = pathToRC(pvec, imagedim);
+            cent.subcube(0, 0, i, 0, 1, i) =
+                arma::mean(1.0 * pathRC, 0) - centroid;
+            // the Rfast::eachrow
+            for (int j = 0; j < numPathCuts - 1; j++) {
+                // ceil but 0-indexed -> floor
+                int ind = std::floor(l / ((1.0 * numPathCuts) / j + 1));
+                pq.subcube(ind, 0, i, ind, 1, i) = pathRC.row(ind) - centroid;
+            }
+        }
+    }
+}
+
+//' getGraphInfo_cpp
+//'
+//' Gather and format the parameter values need to calculate the distance
+// between ' two graphs.
+//'
+//' @param imageList1 A graph
+//' @param imageList2 A graph
+//' @param isProto1 True or false. Is the graph information in prototype format?
+//' @param isProto2 True or false. Is the graph information in prototype format?
+//' @param numPathCuts An integer number of cuts to make when comparing segments
+// of paths ' @return List of formatted parameters
+//'
+//' @noRd
+// [[Rcpp::export]]
+Rcpp::List getGraphInfo_cpp(Rcpp::List imageList1, Rcpp::List imageList2,
+                            bool isProto1, bool isProto2, int numPathCuts) {
+    int numPaths1 = 0;
+    int letterSize1 = 0;
+    graphInfo_subpart1(imageList1, isProto1, numPaths1, letterSize1);
+
+    int numPaths2 = 0;
+    int letterSize2 = 0;
+    graphInfo_subpart1(imageList2, isProto2, numPaths2, letterSize2);
+
+    int pathCheckNum = std::max(numPaths1, numPaths2);
+
+    arma::Cube<double> pq1(numPathCuts - 1, 2, pathCheckNum);
+    arma::Cube<double> pe1(2, 2, pathCheckNum);
+    arma::Cube<double> cent1(1, 2, pathCheckNum);
+    arma::Col<int> len1(pathCheckNum);
+    graphInfo_subpart2(imageList1, isProto1, numPaths1, numPathCuts,  //
+                       pathCheckNum, pq1, pe1, cent1, len1);
+
+    arma::Cube<double> pq2(numPathCuts - 1, 2, pathCheckNum);
+    arma::Cube<double> pe2(2, 2, pathCheckNum);
+    arma::Cube<double> cent2(1, 2, pathCheckNum);
+    arma::Col<int> len2(pathCheckNum);
+    graphInfo_subpart2(imageList2, isProto2, numPaths2, numPathCuts,  //
+                       pathCheckNum, pq2, pe2, cent2, len2);
+
+    Rcpp::LogicalMatrix pathEndPointsMatch(pathCheckNum, pathCheckNum);
+    pathEndPointsMatch.fill(true);
+
+    Rcpp::NumericMatrix weights(pathCheckNum, pathCheckNum);
+    weights.fill(0.0);
+
+    Rcpp::IntegerVector letterSize =
+        Rcpp::IntegerVector::create(letterSize1, letterSize2);
+
+    using Rcpp::_;
+    return Rcpp::List::create(_["numPaths1"] = numPaths1,                    //
+                              _["numPaths2"] = numPaths2,                    //
+                              _["pe1"] = pe1,                                //
+                              _["pe2"] = pe2,                                //
+                              _["pq1"] = pq1,                                //
+                              _["pq2"] = pq2,                                //
+                              _["cent1"] = cent1,                            //
+                              _["cent2"] = cent2,                            //
+                              _["len1"] = len1,                              //
+                              _["len2"] = len2,                              //
+                              _["letterSize"] = letterSize,                  //
+                              _["pathCheckNum"] = pathCheckNum,              //
+                              _["pathEndPointsMatch"] = pathEndPointsMatch,  //
+                              _["weights"] = weights);
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23,13 +23,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // getGraphInfo_cpp
-Rcpp::List getGraphInfo_cpp(Rcpp::List imageList1, Rcpp::List imageList2, bool isProto1, bool isProto2, int numPathCuts);
+Rcpp::List getGraphInfo_cpp(const Rcpp::List& imageList1, const Rcpp::List& imageList2, bool isProto1, bool isProto2, int numPathCuts);
 RcppExport SEXP _handwriter_getGraphInfo_cpp(SEXP imageList1SEXP, SEXP imageList2SEXP, SEXP isProto1SEXP, SEXP isProto2SEXP, SEXP numPathCutsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::List >::type imageList1(imageList1SEXP);
-    Rcpp::traits::input_parameter< Rcpp::List >::type imageList2(imageList2SEXP);
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type imageList1(imageList1SEXP);
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type imageList2(imageList2SEXP);
     Rcpp::traits::input_parameter< bool >::type isProto1(isProto1SEXP);
     Rcpp::traits::input_parameter< bool >::type isProto2(isProto2SEXP);
     Rcpp::traits::input_parameter< int >::type numPathCuts(numPathCutsSEXP);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -22,6 +22,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// getGraphInfo_cpp
+Rcpp::List getGraphInfo_cpp(Rcpp::List imageList1, Rcpp::List imageList2, bool isProto1, bool isProto2, int numPathCuts);
+RcppExport SEXP _handwriter_getGraphInfo_cpp(SEXP imageList1SEXP, SEXP imageList2SEXP, SEXP isProto1SEXP, SEXP isProto2SEXP, SEXP numPathCutsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::List >::type imageList1(imageList1SEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type imageList2(imageList2SEXP);
+    Rcpp::traits::input_parameter< bool >::type isProto1(isProto1SEXP);
+    Rcpp::traits::input_parameter< bool >::type isProto2(isProto2SEXP);
+    Rcpp::traits::input_parameter< int >::type numPathCuts(numPathCutsSEXP);
+    rcpp_result_gen = Rcpp::wrap(getGraphInfo_cpp(imageList1, imageList2, isProto1, isProto2, numPathCuts));
+    return rcpp_result_gen;
+END_RCPP
+}
 // addToFeatures
 List addToFeatures(List FeatureSet, List LetterList, IntegerVector vectorDims);
 RcppExport SEXP _handwriter_addToFeatures(SEXP FeatureSetSEXP, SEXP LetterListSEXP, SEXP vectorDimsSEXP) {
@@ -82,6 +97,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_handwriter_cleanBinaryImage", (DL_FUNC) &_handwriter_cleanBinaryImage, 1},
+    {"_handwriter_getGraphInfo_cpp", (DL_FUNC) &_handwriter_getGraphInfo_cpp, 5},
     {"_handwriter_addToFeatures", (DL_FUNC) &_handwriter_addToFeatures, 3},
     {"_handwriter_rgba2rgb", (DL_FUNC) &_handwriter_rgba2rgb, 1},
     {"_handwriter_rgb2grayscale", (DL_FUNC) &_handwriter_rgb2grayscale, 1},

--- a/tests/testthat/test_ClusterDistanceFunctions.R
+++ b/tests/testthat/test_ClusterDistanceFunctions.R
@@ -239,9 +239,8 @@ test_that("getGraphInfo returns the correct output with two prototype image list
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
   graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, TRUE, TRUE, 5)
-  # bad typechecks, plus weights are NA anyway
-  graph_info2$weights <- graph_info$weights
-  expect_equal(graph_info2, graph_info)
+  expect_equal(graph_info2$numPaths1, 2)
+  expect_equal(graph_info2$numPaths2, 3)
 })
 
 # Test 2: getGraphInfo with two non-prototype image lists
@@ -253,9 +252,8 @@ test_that("getGraphInfo returns the correct output with two non-prototype image 
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
   graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, FALSE, FALSE, 5)
-  # bad typechecks, plus weights are NA anyway
-  graph_info2$weights <- graph_info$weights
-  expect_equal(graph_info2, graph_info)
+  expect_equal(graph_info2$numPaths1, 2)
+  expect_equal(graph_info2$numPaths2, 3)
 })
 
 # Test 3: getGraphInfo with one prototype and one non-prototype image list
@@ -267,9 +265,8 @@ test_that("getGraphInfo returns the correct output with one prototype and one no
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
   graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, TRUE, FALSE, 5)
-  # bad typechecks, plus weights are NA anyway
-  graph_info2$weights <- graph_info$weights
-  expect_equal(graph_info2, graph_info)
+  expect_equal(graph_info2$numPaths1, 2)
+  expect_equal(graph_info2$numPaths2, 3)
 })
 
 ##########################

--- a/tests/testthat/test_ClusterDistanceFunctions.R
+++ b/tests/testthat/test_ClusterDistanceFunctions.R
@@ -238,6 +238,9 @@ test_that("getGraphInfo returns the correct output with two prototype image list
   graph_info <- getGraphInfo(image_list1, image_list2, TRUE, TRUE, 5)
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
+  graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, TRUE, TRUE, 5)
+  expect_equal(graph_info2$numPaths1, 2)
+  expect_equal(graph_info2$numPaths2, 3)
 })
 
 # Test 2: getGraphInfo with two non-prototype image lists
@@ -248,6 +251,9 @@ test_that("getGraphInfo returns the correct output with two non-prototype image 
   graph_info <- getGraphInfo(image_list1, image_list2, FALSE, FALSE, 5)
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
+  graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, FALSE, FALSE, 5)
+  expect_equal(graph_info2$numPaths1, 2)
+  expect_equal(graph_info2$numPaths2, 3)
 })
 
 # Test 3: getGraphInfo with one prototype and one non-prototype image list
@@ -258,6 +264,9 @@ test_that("getGraphInfo returns the correct output with one prototype and one no
   graph_info <- getGraphInfo(image_list1, image_list2, TRUE, FALSE, 5)
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
+  graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, TRUE, FALSE, 5)
+  expect_equal(graph_info2$numPaths1, 2)
+  expect_equal(graph_info2$numPaths2, 3)
 })
 
 ##########################

--- a/tests/testthat/test_ClusterDistanceFunctions.R
+++ b/tests/testthat/test_ClusterDistanceFunctions.R
@@ -239,8 +239,9 @@ test_that("getGraphInfo returns the correct output with two prototype image list
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
   graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, TRUE, TRUE, 5)
-  expect_equal(graph_info2$numPaths1, 2)
-  expect_equal(graph_info2$numPaths2, 3)
+  # bad typechecks, plus weights are NA anyway
+  graph_info2$weights <- graph_info$weights
+  expect_equal(graph_info2, graph_info)
 })
 
 # Test 2: getGraphInfo with two non-prototype image lists
@@ -252,8 +253,9 @@ test_that("getGraphInfo returns the correct output with two non-prototype image 
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
   graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, FALSE, FALSE, 5)
-  expect_equal(graph_info2$numPaths1, 2)
-  expect_equal(graph_info2$numPaths2, 3)
+  # bad typechecks, plus weights are NA anyway
+  graph_info2$weights <- graph_info$weights
+  expect_equal(graph_info2, graph_info)
 })
 
 # Test 3: getGraphInfo with one prototype and one non-prototype image list
@@ -265,8 +267,9 @@ test_that("getGraphInfo returns the correct output with one prototype and one no
   expect_equal(graph_info$numPaths1, 2)
   expect_equal(graph_info$numPaths2, 3)
   graph_info2 <- getGraphInfo_cpp(image_list1, image_list2, TRUE, FALSE, 5)
-  expect_equal(graph_info2$numPaths1, 2)
-  expect_equal(graph_info2$numPaths2, 3)
+  # bad typechecks, plus weights are NA anyway
+  graph_info2$weights <- graph_info$weights
+  expect_equal(graph_info2, graph_info)
 })
 
 ##########################


### PR DESCRIPTION
@stephaniereinders this PR adds a `getGraphInfo_cpp` function which "should" do the exact same thing as `getGraphInfo`. The package builds successfully, but I have not run it with any of the tests yet (we should hold off on merging until we are sure it is correct :sweat_smile: ). Possible types of errors include:

- 0-indexing vs 1-indexing
- wrong `Rcpp::as` type-casting, leading to copies or incorrect data
- a matrix is being copied wrongly (not 100% sure if the `byrow=TRUE` part is working or not)
- There are some details about the `imageList1` and `allPaths` variables that I'd like to confirm
- I don't expect any memory issues because of this, because there are no explicit allocations, and all the calculations are happening inside bounds anyway. But it could still happen.

If `getGraphInfo_cpp` passes the tests, would be fun to know if it speeds things up/reduces memory usage.