### PR TITLE
Fixed bug in fit_model()

### DIFF
--- a/R/batch_processing.R
+++ b/R/batch_processing.R
@@ -147,7 +147,7 @@ process_batch_list <- function(images, output_dir, skip_docs_on_retry=TRUE) {
 #' @md
 process_batch_dir <- function(input_dir, output_dir = ".", skip_docs_on_retry=TRUE) {
   message("Listing documents to be processed...")
-  file_list <- list.files(input_dir, full.names = TRUE)
+  file_list <- list.files(input_dir, pattern = "(.PNG|.png)$", full.names = TRUE)
 
   document_list <- process_batch_list(images=file_list, 
                                       output_dir=output_dir,

--- a/R/cluster_assignment.R
+++ b/R/cluster_assignment.R
@@ -62,7 +62,7 @@ get_clusters_batch <- function(template, input_dir, output_dir, writer_indices, 
   }
 
   # list files in input dir
-  proclist <- list.files(input_dir, full.names = TRUE)
+  proclist <- list.files(input_dir, pattern = ".rds", full.names = TRUE)
 
   if (num_cores > 1) { # run in parallel
     my_cluster <- parallel::makeCluster(num_cores)
@@ -461,7 +461,7 @@ get_clusterassignment <- function(template_dir, input_type, num_graphs = "All", 
   }
 
   # list files in input dir
-  proclist <- list.files(input_dir, full.names = TRUE)
+  proclist <- list.files(input_dir, pattern = '.rds', full.names = TRUE)
 
   my_cluster <- parallel::makeCluster(num_cores)
   doParallel::registerDoParallel(my_cluster)


### PR DESCRIPTION
process_batch_dir() was recently changed so that it creates a log file called problems.txt in the output directory and records any files that couldn't be processed. If the user calls process_batch_dir() with skip_docs_on_retry=TRUE (the default behavior), the problem files are skipped.

However, the problems.txt file causes fit_model() to result in the error: "Error in { : task 1 failed - "error reading from connection".

I fixed this bug by updating list.files() in one of fit_model's internal helper functions, get_clusterassignment, to only list RDS files.

I also updated the external function get_clusters_batch to only list RDS files. And I updated process_batch_list() to only list PNG files. The handwriter package can only input PNG files right now, so if process_batch_list() is called on other image types or non-image files, it will result in an error.