### PR TITLE
fix test of getGraphInfo_cpp

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -16,12 +16,16 @@ cleanBinaryImage <- function(img) {
 #' getGraphInfo_cpp
 #'
 #' Gather and format the parameter values need to calculate the distance
-#' 
+NULL
+
+#'
 #' @param imageList1 A graph
 #' @param imageList2 A graph
 #' @param isProto1 True or false. Is the graph information in prototype format?
 #' @param isProto2 True or false. Is the graph information in prototype format?
 #' @param numPathCuts An integer number of cuts to make when comparing segments
+NULL
+
 #'
 #' @noRd
 getGraphInfo_cpp <- function(imageList1, imageList2, isProto1, isProto2, numPathCuts) {

--- a/tests/testthat/test_ClusterDistanceFunctions.R
+++ b/tests/testthat/test_ClusterDistanceFunctions.R
@@ -209,9 +209,10 @@ create_dummy_image_list <- function(is_proto = TRUE, num_paths = 1) {
       lengths = lengths
     )
   } else {
+    pathends0 = array(path_ends, dim = c(2, 2, num_paths))
     image_list <- list(
       allPaths = lapply(1:num_paths, function(x) 1:x),
-      pathEndsrc = array(path_ends, dim = c(2, 2, num_paths)),
+      pathEndsrc = lapply(1:num_paths, function(x) pathends0[,,x]),
       pathQuarters = path_quarters,
       pathCenter = path_center,
       lengths = lengths,


### PR DESCRIPTION
the test function for getGraphInfo_cpp was producing an error with respect to matrix-conversion, specifically for:

- two non-prototype image lists
- one prototype and one non-prototype image list

Rcpp was throwing an error when trying to convert an element of pathEndsrc into a matrix.

upon closer study, we found that the function initializing the dummy image_list values for the test specified pathEndsrc as an array, while the actual handwriter code always specifies pathEndsrc as a list -- when searching through the handwriter code, we found pathEndsrc was always created via lapply.

the assumption made in the RCpp code is that pathEndsrc is a list of 2x2 matrices, and this assumption was only found to be violated in the testcases. Hence, we patch the test function to ensure pathEndsrc is a list everywhere.